### PR TITLE
utils: mock api client with configurable response

### DIFF
--- a/pytest_reana/test_utils.py
+++ b/pytest_reana/test_utils.py
@@ -13,10 +13,17 @@ from reana_commons.api_client import BaseAPIClient
 
 
 def make_mock_api_client(component):
-    mock_http_client, mock_result, mock_response = Mock(), Mock(), Mock()
+
+    mock_response = Mock()
     mock_response.status_code = 200
-    mock_result.result.return_value = ('_', mock_response)
-    mock_http_client.request.return_value = mock_result
-    mock_api_client = BaseAPIClient(component,
-                                    http_client=mock_http_client)
-    return mock_api_client._client
+    mock_response.raw_bytes = b'Sample downloaded data'
+
+    def mock_api_client(mock_response=mock_response):
+        mock_http_client, mock_result = Mock(), Mock()
+        mock_result.result.return_value = ('_', mock_response)
+        mock_http_client.request.return_value = mock_result
+        mock_api_client = BaseAPIClient(component,
+                                        http_client=mock_http_client)
+        return mock_api_client._client
+
+    return mock_api_client


### PR DESCRIPTION
* Modifies make_mock_api_client() utility to return a callable,
  which takes as a parameter the response which will be returned.
  A call without any arguments has the same default behavior.

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>