### PR TITLE
utils: mock api client returns both responses

### DIFF
--- a/pytest_reana/test_utils.py
+++ b/pytest_reana/test_utils.py
@@ -13,10 +13,17 @@ from reana_commons.api_client import BaseAPIClient
 
 
 def make_mock_api_client(component):
-    mock_http_client, mock_result, mock_response = Mock(), Mock(), Mock()
+
+    mock_response = Mock()
     mock_response.status_code = 200
-    mock_result.result.return_value = ('_', mock_response)
-    mock_http_client.request.return_value = mock_result
-    mock_api_client = BaseAPIClient(component,
-                                    http_client=mock_http_client)
-    return mock_api_client._client
+    mock_response.raw_bytes = b'Sample downloaded data'
+
+    def mock_api_client(mock_response=mock_response):
+        mock_http_client, mock_result = Mock(), Mock()
+        mock_result.result.return_value = ('_', mock_response)
+        mock_http_client.request.return_value = mock_result
+        mock_api_client = BaseAPIClient(component,
+                                        http_client=mock_http_client)
+        return mock_api_client._client
+
+    return mock_api_client

--- a/pytest_reana/test_utils.py
+++ b/pytest_reana/test_utils.py
@@ -14,13 +14,15 @@ from reana_commons.api_client import BaseAPIClient
 
 def make_mock_api_client(component):
 
-    mock_response = Mock()
-    mock_response.status_code = 200
-    mock_response.raw_bytes = b'Sample downloaded data'
+    mock_response, mock_http_response = Mock(), Mock()
+    mock_response = {}
+    mock_http_response.status_code = 200
+    mock_http_response.raw_bytes = b'Sample downloaded data'
 
-    def mock_api_client(mock_response=mock_response):
+    def mock_api_client(mock_response=mock_response,
+                        mock_http_response=mock_http_response):
         mock_http_client, mock_result = Mock(), Mock()
-        mock_result.result.return_value = ('_', mock_response)
+        mock_result.result.return_value = (mock_response, mock_http_response)
         mock_http_client.request.return_value = mock_result
         mock_api_client = BaseAPIClient(component,
                                         http_client=mock_http_client)


### PR DESCRIPTION
* Mock api client returns mocked response and mocked http response
   instead of only mocked response.
    
Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>
Co-authored-by: Diego Rodriguez diego.rodriguez@cern.ch