### PR TITLE
fixtures: update consumer fixture

### DIFF
--- a/pytest_reana/fixtures.py
+++ b/pytest_reana/fixtures.py
@@ -290,7 +290,7 @@ class _BaseConsumerTestIMPL(BaseConsumer):
 
     def get_consumers(self, Consumer, channel):
         """Sample get consumers method."""
-        return [Consumer(queue=self.queue, callbacks=[self.on_message],
+        return [Consumer(self.queue, callbacks=[self.on_message],
                          accept=[self.message_default_format])]
 
     def on_message(self, body, message):
@@ -516,3 +516,13 @@ def sample_serial_workflow_in_db(app, default_user, session, serial_workflow):
     yield workflow
     session.delete(workflow)
     session.commit()
+
+
+def sample_condition_for_starting_queued_workflows():
+    """Sample always true condition."""
+    return True
+
+
+def sample_condition_for_requeueing_workflows():
+    """Sample always false condition."""
+    return False

--- a/pytest_reana/fixtures.py
+++ b/pytest_reana/fixtures.py
@@ -290,7 +290,7 @@ class _BaseConsumerTestIMPL(BaseConsumer):
 
     def get_consumers(self, Consumer, channel):
         """Sample get consumers method."""
-        return [Consumer(queues=self.queues, callbacks=[self.on_message],
+        return [Consumer(queue=self.queue, callbacks=[self.on_message],
                          accept=[self.message_default_format])]
 
     def on_message(self, body, message):

--- a/pytest_reana/version.py
+++ b/pytest_reana/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.5.0.dev20181203"
+__version__ = "0.5.0.dev20190116"


### PR DESCRIPTION
* Updates _BaseConsumerTestIMPL with latest changes in
  reana-commons moving to 1 consumer for 1 queue model.

Connects https://github.com/reanahub/reana/issues/119

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>