### PR TITLE
fixtures: create engine inside app fixture

### DIFF
--- a/pytest_reana/plugin.py
+++ b/pytest_reana/plugin.py
@@ -12,7 +12,7 @@
 from .fixtures import (ConsumerBase, ConsumerBaseOnMessageMock, app,
                        consume_queue, corev1_api_client_with_user_secrets,
                        cwl_workflow_with_name, cwl_workflow_without_name,
-                       db_engine, default_exchange, default_in_memory_producer,
+                       default_exchange, default_in_memory_producer,
                        default_queue, default_user, empty_user_secrets,
                        in_memory_queue_connection, no_db_user,
                        sample_serial_workflow_in_db, sample_workflow_workspace,

--- a/pytest_reana/version.py
+++ b/pytest_reana/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0.dev20200430"
+__version__ = "0.7.0.dev20200604"


### PR DESCRIPTION
* Previously on single test executions the session would be
  pointing to the wrong database URI for tests (defautl), causing
  the tests to fail.