### PR TITLE
setup: require python>=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
     url="https://github.com/reanahub/pytest-reana",
     packages=["pytest_reana",],
     zip_safe=False,
+    python_requires=">=3.6",
     install_requires=install_requires,
     extras_require=extras_require,
     setup_requires=setup_requires,


### PR DESCRIPTION
closes reanahub/reana#601

To test:

```console
$ mkvirtualenv -p python2 py27   
created virtual environment CPython2.7.18.final.0-64 in 927ms
  creator CPython2macOsFramework(dest=/Users/marco/.virtualenvs/py27, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/Users/marco/Library/Application Support/virtualenv)
    added seed packages: pip==20.3.4, setuptools==44.1.1, wheel==0.37.0
  activators BashActivator,CShellActivator,FishActivator,PowerShellActivator,PythonActivator
virtualenvwrapper.user_scripts creating /Users/marco/.virtualenvs/py27/bin/predeactivate
virtualenvwrapper.user_scripts creating /Users/marco/.virtualenvs/py27/bin/postdeactivate
virtualenvwrapper.user_scripts creating /Users/marco/.virtualenvs/py27/bin/preactivate
virtualenvwrapper.user_scripts creating /Users/marco/.virtualenvs/py27/bin/postactivate
virtualenvwrapper.user_scripts creating /Users/marco/.virtualenvs/py27/bin/get_env_details
$ (py27) pip install -e ".[all]" --upgrade
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
Obtaining file:///Users/marco/code/reanahub/pytest-reana
ERROR: Package 'pytest-reana' requires a different Python: 2.7.18 not in '>=3.6'
```