### PR TITLE
docs: update readthedocs to v2 and fix kombu references

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# This file is part of REANA.
+# Copyright (C) 2023 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ include .flake8
 include LICENSE
 include pytest.ini
 include tox.ini
+exclude .readthedocs.yaml
 prune docs/_build
 recursive-include docs *.png
 recursive-include docs *.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -197,5 +197,5 @@ texinfo_documents = [
 
 # Intersphinx configuration
 intersphinx_mapping = {
-    "kombu": ("https://docs.celeryq.dev/projects/kombu/en/latest/", None),
+    "kombu": ("https://docs.celeryq.dev/projects/kombu/en/stable/", None),
 }

--- a/pytest_reana/fixtures.py
+++ b/pytest_reana/fixtures.py
@@ -607,7 +607,7 @@ def consume_queue():
     def _consume_queue(consumer, limit=None):
         """Consume AMQP queue.
 
-        :param consumer: A :class:`kombu.Consumer` to consume from.
+        :param consumer: A class:`kombu.Consumer` to consume from.
         :param limit: Integer which represents how many items to consume
             from the queue, if not specified, the consume method will run
             uninterruptedly.
@@ -629,7 +629,7 @@ def in_memory_queue_connection():
 
     Scope: session
 
-    This fixture offers an in memory :class:`kombu.Connection` scoped to the
+    This fixture offers an in memory class:`kombu.Connection` scoped to the
     testing session.
 
     .. code-block:: python
@@ -645,22 +645,22 @@ def in_memory_queue_connection():
 
 @pytest.fixture
 def default_exchange():
-    """Return a default :class:`kombu.Exchange` created from configuration.
+    """Return a default class:`kombu.Exchange` created from configuration.
 
     Scope: function
 
-    This fixture offers a default :class:`kombu.Exchange`.
+    This fixture offers a default class:`kombu.Exchange`.
     """
     return Exchange("test-exchange", type="direct")
 
 
 @pytest.fixture
 def default_queue(default_exchange):
-    """Return a default :class:`kombu.Queue` created from configuration.
+    """Return a default class:`kombu.Queue` created from configuration.
 
     Scope: function
 
-    This fixture offers a default :class:`kombu.Queue`.
+    This fixture offers a default class:`kombu.Queue`.
     """
     return Queue(
         "test-queue", exchange=default_exchange, routing_key="test-routing-key"
@@ -669,11 +669,11 @@ def default_queue(default_exchange):
 
 @pytest.fixture
 def default_in_memory_producer(in_memory_queue_connection, default_exchange):
-    """Rerturn a :class:`kombu.Producer` connected to in memory queue.
+    """Rerturn a class:`kombu.Producer` connected to in memory queue.
 
     Scope: function
 
-    This fixture offers a default :class:`kombu.Producer` instantiated using
+    This fixture offers a default class:`kombu.Producer` instantiated using
     the ``in_memory_queue_connection``.
 
     .. code-block:: python

--- a/pytest_reana/test_utils.py
+++ b/pytest_reana/test_utils.py
@@ -12,7 +12,6 @@ from reana_commons.api_client import BaseAPIClient
 
 
 def make_mock_api_client(component):
-
     mock_response, mock_http_response = Mock(), Mock()
     mock_response = {}
     mock_http_response.status_code = 200


### PR DESCRIPTION
Switch to the stable version of kombu's docs, as in the latest one some
references are missing.

Closes https://github.com/reanahub/reana/issues/710.