### PR TITLE
deprecations setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -55,7 +55,7 @@ check_sphinx () {
 }
 
 check_pytest () {
-    python setup.py test
+    pytest
 }
 
 check_all () {

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,6 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-[aliases]
-test = pytest
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,6 @@ for key, reqs in extras_require.items():
         continue
     extras_require["all"].extend(reqs)
 
-setup_requires = [
-    "pytest-runner>=2.7",
-]
-
 install_requires = [
     # apispec>=4.0 drops support for marshmallow<3
     "apispec[yaml]>=3.0,<4.0",
@@ -79,7 +75,6 @@ setup(
     python_requires=">=3.8",
     install_requires=install_requires,
     extras_require=extras_require,
-    setup_requires=setup_requires,
     include_package_data=True,
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [tox]
-envlist = py36, py37, py38, py39, py310, py311, py312
+envlist = py38, py39, py310, py311, py312
 
 [testenv]
 deps = pytest
        pytest-cov
-commands = {envpython} setup.py test
+commands = pytest {posargs}


### PR DESCRIPTION
- **ci(pytest): invoke `pytest` directly instead of `setup.py test` (#133)**
- **build(python): remove deprecated `pytest-runner` (#133)**
- **build(python): add minimal `pyproject.toml` (#133)**

Closes https://github.com/reanahub/reana/issues/814