### PR TITLE
ci(tox): fix collecting code coverage information (#134)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     "apispec-webframeworks",
     "check-manifest>=0.25,<1",
     "checksumdir>=1.1.4,<1.2",
-    "coverage>=5.0,<6.0",
+    "coverage>=5.0,<8.0",
     "jsonschema>=3.2.0,<4.0",
     "mock>=3.0,<4.0",
     "pika>=0.12.0,<0.13",

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,22 @@
 # This file is part of REANA.
-# Copyright (C) 2022, 2023 CERN.
+# Copyright (C) 2022, 2023, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [tox]
-envlist = py38, py39, py310, py311, py312
+envlist =
+    py38
+    py39
+    py310
+    py311
+    py312
 
 [testenv]
-deps = pytest
-       pytest-cov
-commands = pytest {posargs}
+deps =
+    pytest
+    pytest-cov
+commands =
+    pytest {posargs}
+package =
+    editable


### PR DESCRIPTION
Fixes `tox` configuration with respect to collecting code coverage information.

Allows higher version of the `coverage` package for Python 3.12 tests.