### PR TITLE
refactor(fixtures): remove unused pkg_resources

### DIFF
--- a/pytest_reana/fixtures.py
+++ b/pytest_reana/fixtures.py
@@ -16,7 +16,6 @@ import os
 import shutil
 from uuid import uuid4
 
-import pkg_resources
 import pytest
 from kombu import Connection, Exchange, Queue
 from kubernetes import client


### PR DESCRIPTION
Remove the unused `pkg_resources` import that was not being used anywhere in the code base. Its removal helps to eliminate deprecation warnings.

Closes reanahub/reana-commons#502