### PR TITLE
ci(python): pin setuptools below 81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<81' py
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
@@ -156,7 +156,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<81' py
           pip install twine wheel
           pip install -e .[all]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,5 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+setuptools<81
 -e .[all]

--- a/pytest_reana/plugin.py
+++ b/pytest_reana/plugin.py
@@ -8,7 +8,6 @@
 
 """Pytest plugin for REANA."""
 
-
 from .fixtures import (
     ConsumerBase,
     ConsumerBaseOnMessageMock,

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -8,7 +8,6 @@
 
 """REANA-pytest-Commmons test fixtures."""
 
-
 from __future__ import absolute_import, print_function
 
 import os
@@ -20,13 +19,11 @@ def test_tmp_shared_volume_path_fixture(testdir):
     """Make sure that pytest accepts our fixture."""
 
     # create a temporary pytest test module
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
         def test_sth(tmp_shared_volume_path):
             import os
             os.path.exists(tmp_shared_volume_path)
-    """
-    )
+    """)
 
     # run pytest with the following cmd args
     testdir.runpytest()

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ envlist =
 deps =
     pytest
     pytest-cov
+    setuptools<81
 commands =
     pytest {posargs}
 package =


### PR DESCRIPTION
Pin setuptools<81 in CI workflows and ReadTheDocs
configuration. This is because the recent setuptools
81.0.0 upgrade removed the pkg_resources module that
is needed at runtime by some dependencies.