### PR TITLE
build(python): remove kubernetes extra from reana-commons

### DIFF
--- a/pytest_reana/fixtures.py
+++ b/pytest_reana/fixtures.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -18,7 +18,6 @@ from uuid import uuid4
 
 import pytest
 from kombu import Connection, Exchange, Queue
-from kubernetes import client
 from mock import Mock, patch
 from reana_commons.consumer import BaseConsumer
 from reana_db.utils import build_workspace_path
@@ -1016,6 +1015,14 @@ def corev1_api_client_with_user_secrets(no_db_user):
 
         Should be used with one of the secret store fixtures.
         """
+        # Importing kubernetes package lazily here in order to avoid declaring
+        # reana-commons[kubernetes] as a hard dependency of pytest-reana, which
+        # would cause circular pip resolution failures.  Components that use
+        # pytest-reana (e.g. reana-server, reana-workflow-controller) already
+        # declare reana-commons[kubernetes] in their own dependencies, so the
+        # kubernetes package is guaranteed to be available at test time.
+        from kubernetes import client
+
         corev1_api_client = Mock()
         metadata = client.V1ObjectMeta(name=f"reana-secretsstore-{no_db_user.id_}")
         metadata.annotations = {"secrets_types": "{}"}

--- a/pytest_reana/version.py
+++ b/pytest_reana/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.95.0a6"
+__version__ = "0.95.0a7"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -46,7 +46,7 @@ install_requires = [
     "pytest-cache>=1.0,<2.0",
     "pytest-cov>=3.0.0,<4.0",
     "pytest>=7.0.0,<9.0.0",
-    "reana-commons[kubernetes]>=0.95.0a1,<0.96.0",
+    "reana-commons>=0.95.0a1,<0.96.0",
     "reana-db>=0.95.0a1,<0.96.0",
     "swagger_spec_validator>=2.1.0",
 ]


### PR DESCRIPTION
Drop the `[kubernetes]` extra from the `reana-commons` dependency to avoid a circular dependency chain that causes pip resolution failures between `pytest-reana` and `reana-commons` packages when Kubernetes versions are being upgraded. Since only one fixture uses Kubernetes client, and since components that use pytest-reana (e.g. `reana-server`, `reana-workflow-controller` etc) already declare
`reana-commons[kubernetes]` in their own dependencies, we can make it a lazy import here instead.