### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,24 @@ jobs:
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
 
+  lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
+
   python-tests:
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,20 @@ jobs:
         run: |
           ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
+  lint-jsonlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint JSON files
+        run: |
+          npm install jsonlint --global
+          ./run-tests.sh --lint-jsonlint
+
   lint-flake8:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,20 @@ jobs:
           pip install flake8
           ./run-tests.sh --lint-flake8
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
+
   lint-manifest:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,20 @@ jobs:
           pip install black
           ./run-tests.sh --format-black
 
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code formatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --format-prettier
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,17 @@ jobs:
           pip install black
           ./run-tests.sh --format-black
 
+  format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
   lint-commitlint:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,116 +4,11 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on: [push, pull_request]
 
 jobs:
-  lint-commitlint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-
-      - name: Install commitlint
-        run: |
-          npm install conventional-changelog-conventionalcommits
-          npm install commitlint@latest
-
-      - name: Check commit message compliance of the recently pushed commit
-        if: github.event_name == 'push'
-        run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
-
-      - name: Check commit message compliance of the pull request
-        if: github.event_name == 'pull_request'
-        run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
-
-  lint-shellcheck:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Runs shell script static analysis
-        run: |
-          sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
-
-  lint-black:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check Python code formatting
-        run: |
-          pip install --upgrade pip
-          pip install black
-          ./run-tests.sh --check-black
-
-  lint-flake8:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check compliance with pep8, pyflakes and circular complexity
-        run: |
-          pip install --upgrade pip
-          pip install flake8
-          ./run-tests.sh --check-flake8
-
-  lint-pydocstyle:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check compliance with Python docstring conventions
-        run: |
-          pip install --upgrade pip
-          pip install pydocstyle
-          ./run-tests.sh --check-pydocstyle
-
-  lint-check-manifest:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check Python manifest completeness
-        run: |
-          pip install --upgrade pip
-          pip install check-manifest
-          ./run-tests.sh --check-manifest
-
   docs-sphinx:
     runs-on: ubuntu-24.04
     steps:
@@ -137,7 +32,112 @@ jobs:
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
-        run: ./run-tests.sh --check-sphinx
+        run: ./run-tests.sh --docs-sphinx
+
+  format-black:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check Python code formatting
+        run: |
+          pip install --upgrade pip
+          pip install black
+          ./run-tests.sh --format-black
+
+  lint-commitlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Install commitlint
+        run: |
+          npm install conventional-changelog-conventionalcommits
+          npm install commitlint@latest
+
+      - name: Check commit message compliance of the recently pushed commit
+        if: github.event_name == 'push'
+        run: |
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
+
+      - name: Check commit message compliance of the pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+
+  lint-flake8:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check compliance with pep8, pyflakes and circular complexity
+        run: |
+          pip install --upgrade pip
+          pip install flake8
+          ./run-tests.sh --lint-flake8
+
+  lint-manifest:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check Python manifest completeness
+        run: |
+          pip install --upgrade pip
+          pip install check-manifest
+          ./run-tests.sh --lint-manifest
+
+  lint-pydocstyle:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check compliance with Python docstring conventions
+        run: |
+          pip install --upgrade pip
+          pip install pydocstyle
+          ./run-tests.sh --lint-pydocstyle
+
+  lint-shellcheck:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Runs shell script static analysis
+        run: |
+          sudo apt-get install shellcheck
+          ./run-tests.sh --lint-shellcheck
 
   python-tests:
     runs-on: ubuntu-24.04
@@ -161,7 +161,7 @@ jobs:
           pip install -e .[all]
 
       - name: Run pytest
-        run: ./run-tests.sh --check-pytest
+        run: ./run-tests.sh --python-tests
 
       - name: Codecov Coverage
         if: matrix.python-version == '3.12'

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+# Allow prompt dollar sign in console examples without showing output
+MD014: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.pytest_cache
+CHANGELOG.md

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,9 +5,13 @@
     ".": {
       "changelog-sections": [
         { "type": "build", "section": "Build", "hidden": false },
-        { "type": "feat", "section": "Features", "hidden": false  },
+        { "type": "feat", "section": "Features", "hidden": false },
         { "type": "fix", "section": "Bug fixes", "hidden": false },
-        { "type": "perf", "section": "Performance improvements", "hidden": false },
+        {
+          "type": "perf",
+          "section": "Performance improvements",
+          "hidden": false
+        },
         { "type": "refactor", "section": "Code refactoring", "hidden": false },
         { "type": "style", "section": "Code style", "hidden": false },
         { "type": "test", "section": "Test suite", "hidden": false },

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,75 +1,76 @@
+<!-- markdownlint-disable MD013 -->
+
 # Changelog
 
 ## 0.9.2 (2023-11-30)
 
-- Changes CI to use the stable release of Python 3.12.
+* Changes CI to use the stable release of Python 3.12.
 
 ## 0.9.1 (2023-09-26)
 
-- Adds support for Python 3.12.
-- Changes `apispec` dependency version in order to be compatible with `PyYAML` v6.
-- Fixes container image fixtures to be Podman-compatible.
-- Fixes Kombu documentation linking.
+* Adds support for Python 3.12.
+* Changes `apispec` dependency version in order to be compatible with `PyYAML` v6.
+* Fixes container image fixtures to be Podman-compatible.
+* Fixes Kombu documentation linking.
 
 ## 0.9.0 (2022-12-13)
 
-- Adds fixture providing example of user secrets needed for Kerberos tests.
-- Adds support for Python 3.11.
-- Fixes location of Celery docs for ReadTheDocs pages.
-- Removes hard-dependency on `black` code formatter version.
+* Adds fixture providing example of user secrets needed for Kerberos tests.
+* Adds support for Python 3.11.
+* Fixes location of Celery docs for ReadTheDocs pages.
+* Removes hard-dependency on `black` code formatter version.
 
 ## 0.8.1 (2022-01-05)
 
-- Adds support for Python 3.10.
+* Adds support for Python 3.10.
 
 ## 0.8.0 (2021-11-22)
 
-- Adds nested Yadage workflow specification fixture.
-- Adds empty workflow workspaces for sample workflows by default.
-- Adds internal representation of a scatter-gather Snakemake workflow fixture.
-- Changes `tmp_shared_volume_path` fixture to be configurable through environment variable.
-- Changes fixtures to run with the full workspace path stored in the database.
-- Removes support for Python 2.
+* Adds nested Yadage workflow specification fixture.
+* Adds empty workflow workspaces for sample workflows by default.
+* Adds internal representation of a scatter-gather Snakemake workflow fixture.
+* Changes `tmp_shared_volume_path` fixture to be configurable through environment variable.
+* Changes fixtures to run with the full workspace path stored in the database.
+* Removes support for Python 2.
 
 ## 0.7.2 (2021-07-02)
 
-- Changes internal dependencies to remove click.
+* Changes internal dependencies to remove click.
 
 ## 0.7.1 (2021-03-17)
 
-- Adds support for Python 3.9.
-- Fixes minor code warnings.
-- Fixes installation by upgrading REANA-DB version.
+* Adds support for Python 3.9.
+* Fixes minor code warnings.
+* Fixes installation by upgrading REANA-DB version.
 
 ## 0.7.0 (2020-10-20)
 
-- Adds new `__reana` database schema for `db` fixture.
-- Fixes a problem related to duplicated database session.
-- Changes code formatting to respect `black` coding style.
-- Changes documentation to single-page layout.
+* Adds new `__reana` database schema for `db` fixture.
+* Fixes a problem related to duplicated database session.
+* Changes code formatting to respect `black` coding style.
+* Changes documentation to single-page layout.
 
 ## 0.6.0 (2019-12-19)
 
-- Adds fixtures for secrets store.
-- Centralises test requirements.
-- Adds Python 3.8 support.
+* Adds fixtures for secrets store.
+* Centralises test requirements.
+* Adds Python 3.8 support.
 
 ## 0.5.0 (2019-04-16)
 
-- Makes workspace path configurable for the `sample_workflow_workspace`
+* Makes workspace path configurable for the `sample_workflow_workspace`
   fixture through the `path` parameter.
-- Adds `sample_serial_workflow_in_db` fixture.
-- Exposes previously hidden `sample_yadage_workflow_in_db` fixture.
-- Adds missing database session close in `session` fixture.
-- Adds helpers to represent starting and requeueing job conditions,
+* Adds `sample_serial_workflow_in_db` fixture.
+* Exposes previously hidden `sample_yadage_workflow_in_db` fixture.
+* Adds missing database session close in `session` fixture.
+* Adds helpers to represent starting and requeueing job conditions,
   `sample_condition_for_starting_queued_workflows` and
   `sample_condition_for_requeueing_workflows`.
 
 ## 0.4.1 (2018-11-06)
 
-- Adds directory including sample workspace data.
+* Adds directory including sample workspace data.
 
 ## 0.4.0 (2018-11-06)
 
-- Initial public release.
-
+* Initial public release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-Bug reports, issues, feature requests, and other contributions are welcome. If you find
-a demonstrable problem that is caused by the REANA code, please:
+Bug reports, issues, feature requests, and other contributions are welcome.
+If you find a demonstrable problem that is caused by the REANA code, please:
 
 1. Search for [already reported problems](https://github.com/reanahub/pytest-reana/issues).
 2. Check if the issue has been fixed or is still reproducible on the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,12 @@
 # Contributing
 
-Bug reports, issues, feature requests, and other contributions are welcome.
-If you find a demonstrable problem that is caused by the REANA code, please:
+Bug reports, issues, feature requests, and other contributions are welcome. If
+you find a demonstrable problem that is caused by the REANA code, please:
 
-1. Search for [already reported problems](https://github.com/reanahub/pytest-reana/issues).
-2. Check if the issue has been fixed or is still reproducible on the
-   latest `master` branch.
+1. Search for
+   [already reported problems](https://github.com/reanahub/pytest-reana/issues).
+2. Check if the issue has been fixed or is still reproducible on the latest
+   `master` branch.
 3. Create an issue, ideally with **a test case**.
 
 If you create a pull request fixing a bug or implementing a feature, you can run

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ include *.sh
 include *.toml
 include *.yaml
 include .dockerignore
+include .editorconfig
 include .flake8
 include LICENSE
 include pytest.ini

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,8 @@ include *.yaml
 include .dockerignore
 include .editorconfig
 include .flake8
+include .prettierignore
+include .prettierrc.yaml
 include LICENSE
 include pytest.ini
 include tox.ini

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 ## About
 
 pytest-REANA is a component of the [REANA](http://www.reana.io/) reusable and
-reproducible research data analysis platform. It provides pytest fixtures and test
-utilities.
+reproducible research data analysis platform. It provides pytest fixtures and
+test utilities.
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+
 ```{include} ../README.md
 :end-before: "## About"
 ```

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -59,6 +59,10 @@ lint_flake8() {
     flake8 .
 }
 
+lint_jsonlint() {
+    find . -name "*.json" -exec jsonlint -q {} \+
+}
+
 lint_manifest() {
     check-manifest
 }
@@ -80,6 +84,7 @@ all() {
     format_black
     lint_commitlint
     lint_flake8
+    lint_jsonlint
     lint_manifest
     lint_pydocstyle
     lint_shellcheck
@@ -95,6 +100,7 @@ help() {
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
     echo "  --lint-flake8        Check linting of Python code"
+    echo "  --lint-jsonlint      Check linting of JSON files"
     echo "  --lint-manifest      Check linting of Python manifest"
     echo "  --lint-pydocstyle    Check linting of Python docstrings"
     echo "  --lint-shellcheck    Check linting of shell scripts"
@@ -114,6 +120,7 @@ case $arg in
 --format-black) format_black ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-flake8) lint_flake8 ;;
+--lint-jsonlint) lint_jsonlint ;;
 --lint-manifest) lint_manifest ;;
 --lint-pydocstyle) lint_pydocstyle ;;
 --lint-shellcheck) lint_shellcheck ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,6 +17,10 @@ format_black() {
     black --check .
 }
 
+format_prettier() {
+    prettier -c .
+}
+
 format_shfmt() {
     shfmt -d .
 }
@@ -94,6 +98,7 @@ python_tests() {
 all() {
     docs_sphinx
     format_black
+    format_prettier
     format_shfmt
     lint_commitlint
     lint_flake8
@@ -112,6 +117,7 @@ help() {
     echo "  --all                Perform all checks [default]"
     echo "  --docs-sphinx        Check Sphinx docs build"
     echo "  --format-black       Check formatting of Python code"
+    echo "  --format-prettier    Check formatting of Markdown etc files"
     echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
@@ -136,6 +142,7 @@ case $arg in
 --help) help ;;
 --docs-sphinx) docs_sphinx ;;
 --format-black) format_black ;;
+--format-prettier) format_prettier ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-flake8) lint_flake8 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -75,6 +75,10 @@ lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
+lint_yamllint() {
+    yamllint .
+}
+
 python_tests() {
     pytest
 }
@@ -88,6 +92,7 @@ all() {
     lint_manifest
     lint_pydocstyle
     lint_shellcheck
+    lint_yamllint
     python_tests
 }
 
@@ -104,6 +109,7 @@ help() {
     echo "  --lint-manifest      Check linting of Python manifest"
     echo "  --lint-pydocstyle    Check linting of Python docstrings"
     echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
     echo "  --python-tests       Check Python test suite"
 }
 
@@ -124,6 +130,7 @@ case $arg in
 --lint-manifest) lint_manifest ;;
 --lint-pydocstyle) lint_pydocstyle ;;
 --lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
 --python-tests) python_tests ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -71,6 +71,10 @@ lint_manifest() {
     check-manifest
 }
 
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 lint_pydocstyle() {
     pydocstyle pytest_reana
 }
@@ -95,6 +99,7 @@ all() {
     lint_flake8
     lint_jsonlint
     lint_manifest
+    lint_markdownlint
     lint_pydocstyle
     lint_shellcheck
     lint_yamllint
@@ -113,6 +118,7 @@ help() {
     echo "  --lint-flake8        Check linting of Python code"
     echo "  --lint-jsonlint      Check linting of JSON files"
     echo "  --lint-manifest      Check linting of Python manifest"
+    echo "  --lint-markdownlint  Check linting of Markdown files"
     echo "  --lint-pydocstyle    Check linting of Python docstrings"
     echo "  --lint-shellcheck    Check linting of shell scripts"
     echo "  --lint-yamllint      Check linting of YAML files"
@@ -135,6 +141,7 @@ case $arg in
 --lint-flake8) lint_flake8 ;;
 --lint-jsonlint) lint_jsonlint ;;
 --lint-manifest) lint_manifest ;;
+--lint-markdownlint) lint_markdownlint ;;
 --lint-pydocstyle) lint_pydocstyle ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2020, 2021, 2023, 2024 CERN.
+# Copyright (C) 2018, 2020, 2021, 2023, 2024, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,23 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+docs_sphinx() {
+    sphinx-build -qnNW docs docs/_build/html
+}
+
+format_black() {
+    black --check .
+}
+
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint >/dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)
@@ -31,7 +43,7 @@ check_commitlint () {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -43,59 +55,68 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
-    find . -name "*.sh" -exec shellcheck {} \+
-}
-
-check_pydocstyle () {
-    pydocstyle pytest_reana
-}
-
-check_black () {
-    black --check .
-}
-
-check_flake8 () {
+lint_flake8() {
     flake8 .
 }
 
-check_manifest () {
+lint_manifest() {
     check-manifest
 }
 
-check_sphinx () {
-    sphinx-build -qnNW docs docs/_build/html
+lint_pydocstyle() {
+    pydocstyle pytest_reana
 }
 
-check_pytest () {
+lint_shellcheck() {
+    find . -name "*.sh" -exec shellcheck {} \+
+}
+
+python_tests() {
     pytest
 }
 
-check_all () {
-    check_commitlint
-    check_shellcheck
-    check_pydocstyle
-    check_black
-    check_flake8
-    check_manifest
-    check_sphinx
-    check_pytest
+all() {
+    docs_sphinx
+    format_black
+    lint_commitlint
+    lint_flake8
+    lint_manifest
+    lint_pydocstyle
+    lint_shellcheck
+    python_tests
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all                Perform all checks [default]"
+    echo "  --docs-sphinx        Check Sphinx docs build"
+    echo "  --format-black       Check formatting of Python code"
+    echo "  --help               Display this help message"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-flake8        Check linting of Python code"
+    echo "  --lint-manifest      Check linting of Python manifest"
+    echo "  --lint-pydocstyle    Check linting of Python docstrings"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --python-tests       Check Python test suite"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    --check-pydocstyle) check_pydocstyle;;
-    --check-black) check_black;;
-    --check-flake8) check_flake8;;
-    --check-manifest) check_manifest;;
-    --check-sphinx) check_sphinx;;
-    --check-pytest) check_pytest;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--all) all ;;
+--help) help ;;
+--docs-sphinx) docs_sphinx ;;
+--format-black) format_black ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-flake8) lint_flake8 ;;
+--lint-manifest) lint_manifest ;;
+--lint-pydocstyle) lint_pydocstyle ;;
+--lint-shellcheck) lint_shellcheck ;;
+--python-tests) python_tests ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,6 +17,10 @@ format_black() {
     black --check .
 }
 
+format_shfmt() {
+    shfmt -d .
+}
+
 lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
@@ -86,6 +90,7 @@ python_tests() {
 all() {
     docs_sphinx
     format_black
+    format_shfmt
     lint_commitlint
     lint_flake8
     lint_jsonlint
@@ -102,6 +107,7 @@ help() {
     echo "  --all                Perform all checks [default]"
     echo "  --docs-sphinx        Check Sphinx docs build"
     echo "  --format-black       Check formatting of Python code"
+    echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
     echo "  --lint-flake8        Check linting of Python code"
@@ -124,6 +130,7 @@ case $arg in
 --help) help ;;
 --docs-sphinx) docs_sphinx ;;
 --format-black) format_black ;;
+--format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-flake8) lint_flake8 ;;
 --lint-jsonlint) lint_jsonlint ;;


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.