### PR TITLE
fix(fixtures): substitute Session in user init patch

### DIFF
--- a/pytest_reana/fixtures.py
+++ b/pytest_reana/fixtures.py
@@ -144,7 +144,7 @@ def user0(app, session):
     user0_id = "00000000-0000-0000-0000-000000000000"
     user = session.query(User).filter_by(id_=user0_id).first()
     if not user:
-        with patch("reana_db.database.Session", return_value=session):
+        with patch("reana_db.database.Session", new=session):
             user = User(id_=user0_id, email="user0@reana.io", access_token="user0token")
         session.add(user)
         session.commit()
@@ -177,7 +177,7 @@ def user1(app, session):
     user1_id = "11111111-1111-1111-1111-111111111111"
     user = session.query(User).filter_by(id_=user1_id).first()
     if not user:
-        with patch("reana_db.database.Session", return_value=session):
+        with patch("reana_db.database.Session", new=session):
             user = User(id_=user1_id, email="user1@reana.io", access_token="user1token")
         session.add(user)
         session.commit()
@@ -210,7 +210,7 @@ def user2(app, session):
     user2_id = "22222222-2222-2222-2222-222222222222"
     user = session.query(User).filter_by(id_=user2_id).first()
     if not user:
-        with patch("reana_db.database.Session", return_value=session):
+        with patch("reana_db.database.Session", new=session):
             user = User(id_=user2_id, email="user2@reana.io", access_token="user2token")
         session.add(user)
         session.commit()

--- a/pytest_reana/fixtures.py
+++ b/pytest_reana/fixtures.py
@@ -106,10 +106,9 @@ def app(base_app):
     engine = create_engine(base_app.config["SQLALCHEMY_DATABASE_URI"])
     base_app.session.bind = engine
     with base_app.app_context():
-        with engine.connect() as connection:
+        with engine.begin() as connection:
             if not engine.dialect.has_schema(connection, "__reana"):
-                with connection.begin():
-                    connection.execute(CreateSchema("__reana"))
+                connection.execute(CreateSchema("__reana"))
         if not database_exists(engine.url):
             create_database(engine.url)
         Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
-    fix(fixtures): substitute Session in user init patch 
- 
    The user fixtures wrapped `User(...)` with
    `patch("reana_db.database.Session", return_value=session)`. That
    form was tailored for the SQLAlchemy 1.x `Resource.query.all()`
    pattern, which internally called `Session()` and returned the
    test session.

    After the SQLAlchemy 2.x refactor in reana-db, `User.__init__`
    now calls `Session.query(Resource).all()` as an attribute on the
    imported `Session`. The `return_value=...` patch leaves attribute
    access on the MagicMock, which yields a chained MagicMock that
    iterates as empty — so no `UserResource` rows are ever created,
    and later `update_users_disk_quota().one()` raises
    `NoResultFound`.

    Use `new=session` so the patch substitutes the real session, and
    `Session.query(Resource).all()` works as intended.

-    fix(fixtures): use engine.begin() for schema creation

    The previous pattern called `connection.begin()` after
    `engine.dialect.has_schema()`, but under SQLAlchemy 2.x the
    `has_schema()` check autobegins a transaction on the connection,
    making the subsequent `connection.begin()` raise
    `InvalidRequestError`.

    Use `engine.begin()` instead, which is the canonical SQLAlchemy
    2.x "begin once" idiom: it opens a transaction, runs the schema
    check and DDL inside it, and commits on context exit.
